### PR TITLE
Filter activities by date

### DIFF
--- a/apis/filters.py
+++ b/apis/filters.py
@@ -8,6 +8,23 @@ from shapely.wkt import loads
 from shapely.geometry import Point
 
 from farm_management.models import FarmParcel
+from farm_activities.models import (
+    FarmCalendarActivity,
+    Alert,
+    # FertilizationOperation,
+    # IrrigationOperation,
+    # CropProtectionOperation,
+    # YieldPredictionObservation,
+    # DiseaseDetectionObservation,
+    # VigorEstimationObservation,
+    # SprayingRecommendationObservation,
+    # Observation,
+    # CropStressIndicatorObservation,
+    # CropGrowthStageObservation,
+    # CompostOperation,
+    # AddRawMaterialOperation,
+    # CompostTurningOperation,
+)
 
 
 @lru_cache(maxsize=10)
@@ -53,3 +70,19 @@ class FarmParcelFilter(filters.FilterSet):
 
         except (ValueError, TypeError, AttributeError):
             return queryset.none()
+
+class BaseCalendarActivityFilter(filters.FilterSet):
+    fromDate = filters.DateTimeFilter(field_name='start_datetime', lookup_expr='gte')
+    toDate = filters.DateTimeFilter(field_name='start_datetime', lookup_expr='lte')
+
+    class Meta:
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class FarmCalendarActivityFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = FarmCalendarActivity
+
+class AlertFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = Alert
+        fields = ['title', 'activity_type', 'severity']

--- a/apis/filters.py
+++ b/apis/filters.py
@@ -11,19 +11,19 @@ from farm_management.models import FarmParcel
 from farm_activities.models import (
     FarmCalendarActivity,
     Alert,
-    # FertilizationOperation,
-    # IrrigationOperation,
-    # CropProtectionOperation,
-    # YieldPredictionObservation,
-    # DiseaseDetectionObservation,
-    # VigorEstimationObservation,
-    # SprayingRecommendationObservation,
-    # Observation,
-    # CropStressIndicatorObservation,
-    # CropGrowthStageObservation,
-    # CompostOperation,
-    # AddRawMaterialOperation,
-    # CompostTurningOperation,
+    FertilizationOperation,
+    IrrigationOperation,
+    CropProtectionOperation,
+    YieldPredictionObservation,
+    DiseaseDetectionObservation,
+    VigorEstimationObservation,
+    SprayingRecommendationObservation,
+    Observation,
+    CropStressIndicatorObservation,
+    CropGrowthStageObservation,
+    CompostOperation,
+    AddRawMaterialOperation,
+    CompostTurningOperation,
 )
 
 
@@ -86,3 +86,68 @@ class AlertFilter(BaseCalendarActivityFilter):
     class Meta(BaseCalendarActivityFilter.Meta):
         model = Alert
         fields = ['title', 'activity_type', 'severity']
+
+class FertilizationOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = FertilizationOperation
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class IrrigationOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = IrrigationOperation
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class CropProtectionOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = CropProtectionOperation
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class ObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = Observation
+        fields = ['title', 'activity_type']
+
+class CropStressIndicatorObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = CropStressIndicatorObservation
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class CropGrowthStageObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = CropGrowthStageObservation
+        fields = ['title', 'activity_type', 'responsible_agent']
+
+class YieldPredictionObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = YieldPredictionObservation
+        fields = ['title', 'activity_type', 'parcel']
+
+class DiseaseDetectionObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = DiseaseDetectionObservation
+        fields = ['title', 'activity_type', 'parcel']
+
+class VigorEstimationObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = VigorEstimationObservation
+        fields = ['title', 'activity_type', 'parcel']
+
+class SprayingRecommendationObservationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = SprayingRecommendationObservation
+        fields = ['title', 'activity_type', 'parcel']
+
+class CompostOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = CompostOperation
+        fields = ['title', 'activity_type', 'compost_pile_id']
+
+class AddRawMaterialOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = AddRawMaterialOperation
+        fields = ['title', 'activity_type']
+
+class CompostTurningOperationFilter(BaseCalendarActivityFilter):
+    class Meta(BaseCalendarActivityFilter.Meta):
+        model = CompostTurningOperation
+        fields = ['title', 'activity_type']

--- a/apis/views/farm_activities.py
+++ b/apis/views/farm_activities.py
@@ -36,17 +36,12 @@ from ..serializers import (
     AddRawMaterialOperationSerializer,
     CompostTurningOperationSerializer,
 )
+from ..filters import (
+    FarmCalendarActivityFilter,
+    AlertFilter,
+)
 
 
-class FarmCalendarActivityViewSet(viewsets.ModelViewSet):
-    """
-    API endpoint that allows FarmCalendarActivity to be viewed or edited.
-    """
-    queryset = FarmCalendarActivity.objects.all().order_by('-start_datetime')
-    serializer_class = FarmCalendarActivitySerializer
-    permission_classes = [permissions.IsAuthenticated]
-
-    filterset_fields = ['title', 'activity_type', 'responsible_agent']
 
 
 class FarmCalendarActivityTypeViewSet(viewsets.ModelViewSet):
@@ -58,6 +53,15 @@ class FarmCalendarActivityTypeViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['name', ]
 
+class FarmCalendarActivityViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows FarmCalendarActivity to be viewed or edited.
+    """
+    queryset = FarmCalendarActivity.objects.all().order_by('-start_datetime')
+    serializer_class = FarmCalendarActivitySerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    filterset_class = FarmCalendarActivityFilter
 
 class AlertViewSet(viewsets.ModelViewSet):
     """
@@ -68,6 +72,7 @@ class AlertViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title', 'activity_type', 'severity']
 
+    filterset_class = AlertFilter
 
 class FertilizationOperationViewSet(viewsets.ModelViewSet):
     """
@@ -77,7 +82,6 @@ class FertilizationOperationViewSet(viewsets.ModelViewSet):
     serializer_class = FertilizationOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title', 'activity_type', 'responsible_agent']
-
 
 class IrrigationOperationViewSet(viewsets.ModelViewSet):
     """
@@ -94,7 +98,6 @@ class IrrigationOperationViewSet(viewsets.ModelViewSet):
             queryset = queryset.filter(parent_activity=self.kwargs['compost_operation_pk'])
         return queryset
 
-
 class CropProtectionOperationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows CropProtectionOperation to be viewed or edited.
@@ -103,7 +106,6 @@ class CropProtectionOperationViewSet(viewsets.ModelViewSet):
     serializer_class = CropProtectionOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title', 'activity_type', 'responsible_agent']
-
 
 class ObservationViewSet(viewsets.ModelViewSet):
     """
@@ -129,7 +131,6 @@ class CropStressIndicatorObservationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'responsible_agent']
 
-
 class CropGrowthStageObservationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows CropGrowthStageObservation to be viewed or edited.
@@ -138,7 +139,6 @@ class CropGrowthStageObservationViewSet(viewsets.ModelViewSet):
     serializer_class = CropGrowthStageObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'responsible_agent']
-
 
 class YieldPredictionObservationViewSet(viewsets.ModelViewSet):
     """
@@ -149,7 +149,6 @@ class YieldPredictionObservationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'parcel']
 
-
 class DiseaseDetectionObservationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows DiseaseDetection to be viewed or edited.
@@ -158,7 +157,6 @@ class DiseaseDetectionObservationViewSet(viewsets.ModelViewSet):
     serializer_class = DiseaseDetectionObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'parcel']
-
 
 class VigorEstimationObservationViewSet(viewsets.ModelViewSet):
     """
@@ -169,7 +167,6 @@ class VigorEstimationObservationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'parcel']
 
-
 class SprayingRecommendationObservationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows SprayingRecommendation to be viewed or edited.
@@ -179,7 +176,6 @@ class SprayingRecommendationObservationViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'parcel']
 
-
 class CompostOperationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows CompostOperation to be viewed or edited.
@@ -188,7 +184,6 @@ class CompostOperationViewSet(viewsets.ModelViewSet):
     serializer_class = CompostOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
     filterset_fields = ['title','activity_type', 'compost_pile_id']
-
 
 class AddRawMaterialOperationViewSet(viewsets.ModelViewSet):
     """

--- a/apis/views/farm_activities.py
+++ b/apis/views/farm_activities.py
@@ -36,12 +36,24 @@ from ..serializers import (
     AddRawMaterialOperationSerializer,
     CompostTurningOperationSerializer,
 )
+
 from ..filters import (
     FarmCalendarActivityFilter,
     AlertFilter,
+    FertilizationOperationFilter,
+    IrrigationOperationFilter,
+    CropProtectionOperationFilter,
+    ObservationFilter,
+    CropStressIndicatorObservationFilter,
+    CropGrowthStageObservationFilter,
+    YieldPredictionObservationFilter,
+    DiseaseDetectionObservationFilter,
+    VigorEstimationObservationFilter,
+    SprayingRecommendationObservationFilter,
+    CompostOperationFilter,
+    AddRawMaterialOperationFilter,
+    CompostTurningOperationFilter
 )
-
-
 
 
 class FarmCalendarActivityTypeViewSet(viewsets.ModelViewSet):
@@ -51,7 +63,8 @@ class FarmCalendarActivityTypeViewSet(viewsets.ModelViewSet):
     queryset = FarmCalendarActivityType.objects.all().order_by('-name')
     serializer_class = FarmCalendarActivityTypeSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['name', ]
+    filterset_fields = ['name', 'category']
+
 
 class FarmCalendarActivityViewSet(viewsets.ModelViewSet):
     """
@@ -62,6 +75,7 @@ class FarmCalendarActivityViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated]
 
     filterset_class = FarmCalendarActivityFilter
+
 
 class AlertViewSet(viewsets.ModelViewSet):
     """
@@ -74,6 +88,7 @@ class AlertViewSet(viewsets.ModelViewSet):
 
     filterset_class = AlertFilter
 
+
 class FertilizationOperationViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows FertilizationOperation to be viewed or edited.
@@ -81,7 +96,8 @@ class FertilizationOperationViewSet(viewsets.ModelViewSet):
     queryset = FertilizationOperation.objects.all().order_by('-start_datetime')
     serializer_class = FertilizationOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title', 'activity_type', 'responsible_agent']
+    filterset_class = FertilizationOperationFilter
+
 
 class IrrigationOperationViewSet(viewsets.ModelViewSet):
     """
@@ -90,13 +106,14 @@ class IrrigationOperationViewSet(viewsets.ModelViewSet):
     queryset = IrrigationOperation.objects.all().order_by('-start_datetime')
     serializer_class = IrrigationOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title', 'activity_type', 'responsible_agent']
+    filterset_class = IrrigationOperationFilter
 
     def get_queryset(self):
         queryset = super().get_queryset()
         if self.kwargs.get('compost_operation_pk'):
             queryset = queryset.filter(parent_activity=self.kwargs['compost_operation_pk'])
         return queryset
+
 
 class CropProtectionOperationViewSet(viewsets.ModelViewSet):
     """
@@ -105,7 +122,8 @@ class CropProtectionOperationViewSet(viewsets.ModelViewSet):
     queryset = CropProtectionOperation.objects.all().order_by('-start_datetime')
     serializer_class = CropProtectionOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title', 'activity_type', 'responsible_agent']
+    filterset_class = CropProtectionOperationFilter
+
 
 class ObservationViewSet(viewsets.ModelViewSet):
     """
@@ -114,13 +132,14 @@ class ObservationViewSet(viewsets.ModelViewSet):
     queryset = Observation.objects.all().order_by('-start_datetime')
     serializer_class = ObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type']
+    filterset_class = ObservationFilter
 
     def get_queryset(self):
         queryset = super().get_queryset()
         if self.kwargs.get('compost_operation_pk'):
             queryset = queryset.filter(parent_activity=self.kwargs['compost_operation_pk'])
         return queryset
+
 
 class CropStressIndicatorObservationViewSet(viewsets.ModelViewSet):
     """
@@ -129,7 +148,8 @@ class CropStressIndicatorObservationViewSet(viewsets.ModelViewSet):
     queryset = CropStressIndicatorObservation.objects.all().order_by('-start_datetime')
     serializer_class = CropStressIndicatorObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'responsible_agent']
+    filterset_class = CropStressIndicatorObservationFilter
+
 
 class CropGrowthStageObservationViewSet(viewsets.ModelViewSet):
     """
@@ -138,7 +158,8 @@ class CropGrowthStageObservationViewSet(viewsets.ModelViewSet):
     queryset = CropGrowthStageObservation.objects.all().order_by('-start_datetime')
     serializer_class = CropGrowthStageObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'responsible_agent']
+    filterset_class = CropGrowthStageObservationFilter
+
 
 class YieldPredictionObservationViewSet(viewsets.ModelViewSet):
     """
@@ -147,7 +168,8 @@ class YieldPredictionObservationViewSet(viewsets.ModelViewSet):
     queryset = YieldPredictionObservation.objects.all().order_by('-start_datetime')
     serializer_class = YieldPredictionObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'parcel']
+    filterset_class = YieldPredictionObservationFilter
+
 
 class DiseaseDetectionObservationViewSet(viewsets.ModelViewSet):
     """
@@ -156,7 +178,8 @@ class DiseaseDetectionObservationViewSet(viewsets.ModelViewSet):
     queryset = DiseaseDetectionObservation.objects.all().order_by('-start_datetime')
     serializer_class = DiseaseDetectionObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'parcel']
+    filterset_class = DiseaseDetectionObservationFilter
+
 
 class VigorEstimationObservationViewSet(viewsets.ModelViewSet):
     """
@@ -165,7 +188,8 @@ class VigorEstimationObservationViewSet(viewsets.ModelViewSet):
     queryset = VigorEstimationObservation.objects.all().order_by('-start_datetime')
     serializer_class = VigorEstimationObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'parcel']
+    filterset_class = VigorEstimationObservationFilter
+
 
 class SprayingRecommendationObservationViewSet(viewsets.ModelViewSet):
     """
@@ -174,7 +198,8 @@ class SprayingRecommendationObservationViewSet(viewsets.ModelViewSet):
     queryset = SprayingRecommendationObservation.objects.all().order_by('-start_datetime')
     serializer_class = SprayingRecommendationObservationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'parcel']
+    filterset_class = SprayingRecommendationObservationFilter
+
 
 class CompostOperationViewSet(viewsets.ModelViewSet):
     """
@@ -183,7 +208,8 @@ class CompostOperationViewSet(viewsets.ModelViewSet):
     queryset = CompostOperation.objects.all().prefetch_related('nested_activities').order_by('-start_datetime')
     serializer_class = CompostOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title','activity_type', 'compost_pile_id']
+    filterset_class = CompostOperationFilter
+
 
 class AddRawMaterialOperationViewSet(viewsets.ModelViewSet):
     """
@@ -192,13 +218,14 @@ class AddRawMaterialOperationViewSet(viewsets.ModelViewSet):
     queryset = AddRawMaterialOperation.objects.all().order_by('-start_datetime')
     serializer_class = AddRawMaterialOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title', 'activity_type']
+    filterset_class = AddRawMaterialOperationFilter
 
     def get_queryset(self):
         queryset = super().get_queryset()
         if self.kwargs.get('compost_operation_pk'):
             queryset = queryset.filter(parent_activity=self.kwargs['compost_operation_pk'])
         return queryset
+
 
 class CompostTurningOperationViewSet(viewsets.ModelViewSet):
     """
@@ -207,7 +234,7 @@ class CompostTurningOperationViewSet(viewsets.ModelViewSet):
     queryset = CompostTurningOperation.objects.all().order_by('-start_datetime')
     serializer_class = CompostTurningOperationSerializer
     permission_classes = [permissions.IsAuthenticated]
-    filterset_fields = ['title', 'activity_type']
+    filterset_class = CompostTurningOperationFilter
 
     def get_queryset(self):
         queryset = super().get_queryset()

--- a/schema.yml
+++ b/schema.yml
@@ -23,9 +23,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -482,6 +492,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: severity
         schema:
           type: string
@@ -501,6 +516,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -723,9 +743,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -805,9 +835,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -1062,9 +1102,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -1318,6 +1368,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -1325,6 +1380,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -1573,9 +1633,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -1965,9 +2035,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -2192,6 +2272,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -2199,6 +2284,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -2423,6 +2513,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -2430,6 +2525,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -2653,6 +2753,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -2660,6 +2765,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -2878,6 +2988,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: parcel
         schema:
           type: string
@@ -2886,6 +3001,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -3569,6 +3689,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -3576,6 +3701,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -3782,6 +3912,18 @@ paths:
       description: API endpoint that allows FarmCalendarActivityType to be viewed
         or edited.
       parameters:
+      - in: query
+        name: category
+        schema:
+          type: string
+          enum:
+          - activity
+          - alert
+          - observation
+        description: |-
+          * `activity` - Activity
+          * `observation` - Observation
+          * `alert` - Alert
       - in: query
         name: format
         schema:
@@ -4508,6 +4650,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -4515,6 +4662,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -5199,6 +5351,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: responsible_agent
         schema:
           type: string
@@ -5206,6 +5363,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -5424,9 +5586,19 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -5874,6 +6046,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: parcel
         schema:
           type: string
@@ -5882,6 +6059,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -6105,6 +6287,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: parcel
         schema:
           type: string
@@ -6113,6 +6300,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:
@@ -6331,6 +6523,11 @@ paths:
           - json
           - jsonld
       - in: query
+        name: fromDate
+        schema:
+          type: string
+          format: date-time
+      - in: query
         name: parcel
         schema:
           type: string
@@ -6339,6 +6536,11 @@ paths:
         name: title
         schema:
           type: string
+      - in: query
+        name: toDate
+        schema:
+          type: string
+          format: date-time
       tags:
       - api
       security:


### PR DESCRIPTION
Added to all endpoints for listing calendar activities (generic and built-in types) a filter for the start date of the activity (for simplicity only considering here the start date rather the end date, since the activities and observations might not have a end date).

The url parameter filters are `fromDate` and `toDate` eg: 
`?fromDate=2025-08-12&toDate=2025-08-13`

Also updated the API schema.yml.

refs https://github.com/agstack/OpenAgri-FarmCalendar/issues/105